### PR TITLE
Add account exclusion from total available cash-on-hand

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -74,6 +74,6 @@ class AccountsController < ApplicationController
   protected
 
   def account_params
-    params.require(:account).permit(:hidden_from_snapshot)
+    params.require(:account).permit(:hidden_from_snapshot, :exclude_from_available)
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -16,6 +16,11 @@ class DashboardController < ApplicationController
 
     @funds = Fund.order(:name).all
 
+    @cash_total = @accounts.map(&:cash_amount).compact.sum
+    @credit_total = @accounts.map(&:credit_amount).compact.sum
+    @uncleared_total = @accounts.map(&:uncleared_amount).compact.sum
+    @available_total = @accounts.reject { |a| a.exclude_from_available }.map(&:available_amount).compact.sum
+
     respond_to do |format|
       format.html
       format.csv { send_data to_csv(@transactions), filename: "transactions-#{Date.today}.csv" }

--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -27,6 +27,11 @@
       <%= form.check_box :hidden_from_snapshot, class: 'form-check-input' %>
       <%= form.label 'Hide from Snapshot', class: 'form-check-label' %>
   </div>
+
+  <div class="form-check">
+      <%= form.check_box :exclude_from_available, class: 'form-check-input' %>
+      <%= form.label 'Exclude from Available Balance', class: 'form-check-label' %>
+  </div>
  
   <p>
     <%= form.submit class: 'btn btn-primary' %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -74,10 +74,10 @@
       <td>
         <strong>Total:</strong>
       </td>
-      <td style="font-weight: bold;"><%=number_to_currency(@accounts.map(&:cash_amount).compact.sum)%></td>
-      <td style="font-weight: bold;"><%=number_to_currency(@accounts.map(&:credit_amount).compact.sum)%></td>
-      <td style="font-weight: bold;"><%=number_to_currency(@accounts.map(&:uncleared_amount).compact.sum)%></td>
-      <td style="font-weight: bold;"><%=number_to_currency(@accounts.map(&:available_amount).compact.sum)%></td>
+      <td style="font-weight: bold;"><%=number_to_currency(@cash_total)%></td>
+      <td style="font-weight: bold;"><%=number_to_currency(@credit_total)%></td>
+      <td style="font-weight: bold;"><%=number_to_currency(@uncleared_total)%></td>
+      <td style="font-weight: bold;"><%=number_to_currency(@available_total)%></td>
 
     </tr>
     <% @accounts.each do |a| %>
@@ -93,7 +93,7 @@
         <td><%=number_to_currency(a.cash_amount)%></td>
         <td><%=number_to_currency(a.credit_amount)%></td>
         <td><%=number_to_currency(a.uncleared_amount) if a.uncleared_amount%></td>
-        <td><%=number_to_currency(a.available_amount) if a.available_amount%></td>
+        <td <% if a.exclude_from_available%>class="text-muted"<% end %>><%=number_to_currency(a.available_amount) if a.available_amount%></td>
 
       </tr>
     <% end %>

--- a/db/migrate/20191002011028_add_exclude_from_available.rb
+++ b/db/migrate/20191002011028_add_exclude_from_available.rb
@@ -1,0 +1,5 @@
+class AddExcludeFromAvailable < ActiveRecord::Migration[5.2]
+  def change
+    add_column :accounts, :exclude_from_available, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_02_001618) do
+ActiveRecord::Schema.define(version: 2019_10_02_011028) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 2019_10_02_001618) do
     t.datetime "last_synced_at"
     t.datetime "last_sync_error_at"
     t.text "last_sync_error"
+    t.boolean "exclude_from_available", default: false
     t.index ["account_id"], name: "index_accounts_on_account_id"
     t.index ["connection_id"], name: "index_accounts_on_connection_id"
   end


### PR DESCRIPTION
This PR adds the option to exclude an account from the total available cash-on-hand. This allows cash accounts to display on the dashboard that are not included in the cash available.