### PR TITLE
Editable funds and auto clear

### DIFF
--- a/app/controllers/funds_controller.rb
+++ b/app/controllers/funds_controller.rb
@@ -46,7 +46,7 @@ class FundsController < ApplicationController
   private
 
   def fund_params
-    params.require(:fund).permit(:name, :account_id)
+    params.require(:fund).permit(:name, :account_id, :auto_clear)
   end 
 
   def to_csv(transactions)

--- a/app/controllers/funds_controller.rb
+++ b/app/controllers/funds_controller.rb
@@ -1,6 +1,6 @@
 class FundsController < ApplicationController
   def index
-    @funds = Fund.all
+    @funds = Fund.order(:name).all
   end
 
   def new 
@@ -27,6 +27,20 @@ class FundsController < ApplicationController
  
     @fund.save
     redirect_to @fund
+  end
+
+  def edit
+    @fund = Fund.find(params[:id])
+  end
+
+  def update
+    @fund = Fund.find(params[:id])
+ 
+    if @fund.update(fund_params)
+      redirect_to @fund
+    else
+      render 'edit'
+    end
   end
 
   private

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -6,9 +6,9 @@ class TransactionsController < ApplicationController
 
   def assign
     raise "No fund given" unless params[:fund_id].present?
-    raise "Invalid fund" unless Fund.find(params[:fund_id])
+    raise "Invalid fund" unless (fund = Fund.find(params[:fund_id]))
     @transaction = Transaction.find(params[:id])
-    @transaction.update(fund_id: params[:fund_id])
+    @transaction.update(fund_id: params[:fund_id], cleared: fund.auto_clear)
   end
 
   def split_form

--- a/app/views/funds/edit.html.erb
+++ b/app/views/funds/edit.html.erb
@@ -11,6 +11,11 @@
     <%= form.label :account %><br>
     <%= form.select :account_id, Account.all.collect { |a| [ "#{a.connection.name} - #{a.name}", a.id ] }.sort_by {|i| i[0] }, include_blank: true %>
   </p>
+
+  <div class="form-check">
+      <%= form.check_box :auto_clear, class: 'form-check-input' %>
+      <%= form.label 'Automatically clear assigned transactions?', class: 'form-check-label' %>
+  </div>
  
   <p>
     <%= form.submit %>

--- a/app/views/funds/edit.html.erb
+++ b/app/views/funds/edit.html.erb
@@ -1,0 +1,18 @@
+<h1>Edit Fund</h1>
+
+
+<%= form_with(model: @fund, local: true) do |form| %>
+  <p>
+    <%= form.label :name %><br>
+    <%= form.text_field :name %>
+  </p>
+ 
+  <p>
+    <%= form.label :account %><br>
+    <%= form.select :account_id, Account.all.collect { |a| [ "#{a.connection.name} - #{a.name}", a.id ] }.sort_by {|i| i[0] }, include_blank: true %>
+  </p>
+ 
+  <p>
+    <%= form.submit %>
+  </p>
+<% end %>

--- a/app/views/funds/new.html.erb
+++ b/app/views/funds/new.html.erb
@@ -11,6 +11,11 @@
     <%= form.label :account %><br>
     <%= form.select :account_id, Account.all.collect { |a| [ "#{a.connection.name} - #{a.name}", a.id ] }.sort_by {|i| i[0] }, include_blank: true %>
   </p>
+
+  <div class="form-check">
+      <%= form.check_box :auto_clear, class: 'form-check-input' %>
+      <%= form.label 'Automatically clear assigned transactions?', class: 'form-check-label' %>
+  </div>
  
   <p>
     <%= form.submit %>

--- a/app/views/funds/show.html.erb
+++ b/app/views/funds/show.html.erb
@@ -4,6 +4,7 @@
 </div>
 
 <div>
+<%= link_to 'Edit', edit_fund_path(@fund) %> |
 <%= link_to 'Funds', funds_path %> | 
 <%= link_to 'Dashboard', root_path %>
 </div>

--- a/db/migrate/20191003002810_add_autoclear.rb
+++ b/db/migrate/20191003002810_add_autoclear.rb
@@ -1,0 +1,5 @@
+class AddAutoclear < ActiveRecord::Migration[5.2]
+  def change
+    add_column :funds, :auto_clear, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_02_011028) do
+ActiveRecord::Schema.define(version: 2019_10_03_002810) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,6 +51,7 @@ ActiveRecord::Schema.define(version: 2019_10_02_011028) do
     t.bigint "account_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "auto_clear", default: false
     t.index ["account_id"], name: "index_funds_on_account_id"
   end
 


### PR DESCRIPTION
This PR updates funds to be editable through the UI, and adds an "auto clear" capability to clear transactions when they are assigned to this fund (meaning there is no further action required).