### PR TITLE
Hide archived accounts from credit card display

### DIFF
--- a/app/controllers/credit_cards_controller.rb
+++ b/app/controllers/credit_cards_controller.rb
@@ -4,7 +4,8 @@ class CreditCardsController < ApplicationController
   def index
     @credit_cards = Account
                        .joins(:connection)
-                       .where(connections: { family_id: @family.id })
+                       .where(connections: { family_id: @family.id, archived: false })
+                       .where(archived: false)
                        .where(account_type: 'credit')
                        .order(balance_current: :desc)
                        .all


### PR DESCRIPTION
This PR hides all bank connections and accounts that are archived from the credit card summary page.