### PR TITLE
Fix bugs in connection save routing

### DIFF
--- a/app/controllers/connections_controller.rb
+++ b/app/controllers/connections_controller.rb
@@ -21,12 +21,11 @@ class ConnectionsController < ApplicationController
   end
 
   def update
-    authorize! :update, @connection
-
     @connection = Connection.find(params[:id])
+    authorize! :update, @connection
  
     if @connection.update(connection_params)
-      redirect_to @connection
+      redirect_to connection_path(@family, @connection)
     else
       render 'edit'
     end

--- a/app/views/connections/edit.html.erb
+++ b/app/views/connections/edit.html.erb
@@ -7,7 +7,7 @@
 
 <%= link_to 'Connections', connections_path %>
 
-<%= form_with model: @connection, local: true do |form| %>
+<%= form_with model: @connection, url: connection_url(@family, @connection), local: true do |form| %>
   <div class="form-group">
     <label>Name</label>
     <%= form.text_field :name, class: 'form-control' %>

--- a/app/views/connections/new.html.erb
+++ b/app/views/connections/new.html.erb
@@ -5,7 +5,7 @@
 
 <h1>New Connection</h1>
 
-<%= form_with scope: :connection, url: connections_path, local: true do |form| %>
+<%= form_with scope: :connection, url: connections_url(@family), local: true do |form| %>
   <div class="form-group">
     <label>Name</label>
     <%= form.text_field :name, class: 'form-control' %>


### PR DESCRIPTION
Previously, routing bugs preventing the save
button from working on the connections view.

Additionally, an authorization bug caused saving
to fail even when the routing was corrected.

Both of these issues are now resolved.