### PR TITLE
Fix assign transaction

### DIFF
--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -5,7 +5,7 @@
               data: { confirm: 'Are you sure?' } %> |
 
 <%= link_to 'Edit', edit_connection_account_path(@family, @connection, @account) %> |
-<%= link_to 'Dashboard', root_path %>
+<%= link_to 'Dashboard', dashboard_path(@family) %>
 
 
 

--- a/app/views/connections/index.html.erb
+++ b/app/views/connections/index.html.erb
@@ -1,7 +1,7 @@
 <h1>Connection</h1>
 
 <%= link_to 'New Connection', new_connection_path %> |
-<%= link_to 'Dashboard', root_path %>
+<%= link_to 'Dashboard', dashboard_path(@family) %>
 
 <% @tables.each do |tbl| %>
 

--- a/app/views/connections/show.html.erb
+++ b/app/views/connections/show.html.erb
@@ -5,7 +5,7 @@
               method: :post,
               data: { confirm: 'Are you sure?' } %> |
 <%= link_to 'Edit', edit_connection_path(@family, @connection) %> |
-<%= link_to 'Dashboard', root_path %>
+<%= link_to 'Dashboard', dashboard_path(@family) %>
 
  (<%=@connection.item_id%>)
 

--- a/app/views/credit_cards/index.html.erb
+++ b/app/views/credit_cards/index.html.erb
@@ -1,6 +1,6 @@
 <h1>Credit Cards</h1>
 
-<%= link_to 'Dashboard', root_path %>
+<%= link_to 'Dashboard', dashboard_path(@family) %>
 
 <table class="table">
   <thead>

--- a/app/views/funds/index.html.erb
+++ b/app/views/funds/index.html.erb
@@ -6,7 +6,7 @@
 <h1>Funds</h1>
 
 <%= link_to "New Fund", new_fund_path %> |
-<%= link_to 'Dashboard', root_path %>
+<%= link_to 'Dashboard', dashboard_path(@family) %>
 
 <canvas id="funds-by-month"></canvas>
 

--- a/app/views/funds/show.html.erb
+++ b/app/views/funds/show.html.erb
@@ -8,7 +8,7 @@
 <div>
 <%= link_to 'Edit', edit_fund_path(@fund) %> |
 <%= link_to 'Funds', funds_path %> | 
-<%= link_to 'Dashboard', root_path %>
+<%= link_to 'Dashboard', dashboard_path(@family) %>
 </div>
 
 <h2>Transaction Inbox</h2>

--- a/app/views/money_mover/index.html.erb
+++ b/app/views/money_mover/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= link_to "First of Month", money_mover_path(cycle: 1) %> |
 <%= link_to "Mid-Month", money_mover_path(cycle: 16) %> |
-<%= link_to 'Dashboard', root_path %>
+<%= link_to 'Dashboard', dashboard_path(@family) %>
 
 <table class="table">
   <thead>

--- a/app/views/transactions/all.html.erb
+++ b/app/views/transactions/all.html.erb
@@ -56,7 +56,7 @@ Showing page <%=@page%> of <%=@page_count%> ( <%=@transaction_count%> total tran
     $(select).attr('disabled', true);
     let fundId = $(select).val();
     $.ajax({
-      url: '/connections/' + connectionId + '/accounts/' + accountId + '/transactions/' + transactionId + '/assign?fund_id=' + fundId,
+      url: '/families/<%=@family.id%>/connections/' + connectionId + '/accounts/' + accountId + '/transactions/' + transactionId + '/assign?fund_id=' + fundId,
       type: 'post',
       data: {},
       headers: {

--- a/app/views/transactions/all.html.erb
+++ b/app/views/transactions/all.html.erb
@@ -1,6 +1,6 @@
 <h1>Transactions List</h1>
 
-<%= link_to 'Dashboard', root_path %>
+<%= link_to 'Dashboard', dashboard_path(@family) %>
 
 <div>
 Showing page <%=@page%> of <%=@page_count%> ( <%=@transaction_count%> total transactions, <%=@per_page%> transactions per page).


### PR DESCRIPTION
This PR fixes a bug in the assign transaction control where the family ID parameter
was not included. This caused the routing to return a 404 and the transaction
assignment to fail.

The PR also fixes a number of routing bugs to the dashboard where links failed
to include the family ID parameter.